### PR TITLE
:lock: Protect API routes

### DIFF
--- a/src/app/(password-protected)/ajout-structure/[dnaCode]/layout.tsx
+++ b/src/app/(password-protected)/ajout-structure/[dnaCode]/layout.tsx
@@ -12,10 +12,9 @@ export default async function RootLayout({
   const { dnaCode } = await params;
 
   try {
-    const result = await fetch(
-      `${process.env.NEXT_URL}/api/structures/dna/${dnaCode}`,
-      { next: { revalidate: 0 } }
-    );
+    const result = await fetch(`/api/structures/dna/${dnaCode}`, {
+      next: { revalidate: 0 },
+    });
 
     if (!result.ok) {
       if (result.status === 404) {

--- a/src/middleware-config.ts
+++ b/src/middleware-config.ts
@@ -1,0 +1,46 @@
+export type Protection = "proconnect" | "password" | "either";
+
+export const apiProtections: {
+  [routePattern: string]: {
+    [method: string]: Protection;
+  };
+} = {
+  "/api/structures": {
+    GET: "proconnect",
+    PUT: "proconnect",
+    POST: "password",
+  },
+  "/api/structures/[id]": {
+    GET: "proconnect",
+    HEAD: "proconnect",
+  },
+  "/api/structures/dna/[id]": {
+    GET: "proconnect",
+    HEAD: "proconnect",
+  },
+  "/api/files/[id]": {
+    GET: "either",
+    HEAD: "either",
+    DELETE: "either",
+  },
+  "/api/files": {
+    GET: "either",
+    POST: "either",
+  },
+  "/api/operateurs": {
+    GET: "proconnect",
+    POST: "proconnect",
+  },
+};
+
+export const proConnectProtectedPaths = [
+  "/structures",
+  "/operateurs",
+  "/statistiques",
+];
+
+export const passwordProtectedPath = "/ajout-structure";
+
+export const noProtectionPath = "/mot-de-passe";
+
+export const signInRoute = "/connexion";

--- a/src/middleware-utils.ts
+++ b/src/middleware-utils.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+
+import { apiProtections, Protection } from "./middleware-config";
+
+export const matchApiRoute = (
+  request: NextRequest,
+  pathname: string
+): {
+  pattern: string;
+  method: string;
+  protection: Protection;
+} | null => {
+  for (const pattern in apiProtections) {
+    const regex = new RegExp("^" + pattern.replace(/\[id\]/g, "[^\\/]+") + "$");
+    if (regex.test(pathname)) {
+      const method = Object.keys(apiProtections[pattern]).find(
+        (m) => m === request.method
+      );
+      if (method) {
+        return { pattern, method, protection: apiProtections[pattern][method] };
+      }
+    }
+  }
+  return null;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,20 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withAuth } from "next-auth/middleware";
 
+import {
+  noProtectionPath,
+  passwordProtectedPath,
+  proConnectProtectedPaths,
+  Protection,
+  signInRoute,
+} from "./middleware-config";
+import { matchApiRoute } from "./middleware-utils";
+
 const proConnectMiddleware = withAuth(() => NextResponse.next(), {
   callbacks: {
     authorized: ({ token }) => {
+      console.log(">>>>>>>>>>>>>>>>", token !== null);
       return token !== null;
     },
   },
   pages: {
-    signIn: "/connexion",
+    signIn: signInRoute,
   },
 });
 
 const protectByPassword = (request: NextRequest): NextResponse | undefined => {
   const url = request.nextUrl;
-  if (url.pathname.startsWith("/ajout-structure")) {
+  if (url.pathname.startsWith(passwordProtectedPath)) {
     const passwordCookie = request.cookies.get("mot-de-passe");
     if (passwordCookie?.value !== process.env.PAGE_PASSWORD) {
       const loginUrl = new URL("/mot-de-passe", request.url);
@@ -25,20 +35,52 @@ const protectByPassword = (request: NextRequest): NextResponse | undefined => {
   return undefined;
 };
 
-export async function middleware(request: NextRequest) {
-  const protectedPaths = ["/structures", "/operateurs", "/statistiques"];
-  const isProtected = protectedPaths.some((path) =>
-    request.nextUrl.pathname.startsWith(path)
-  );
+const handleProtection = async (
+  request: NextRequest,
+  protection: Protection
+): Promise<NextResponse | undefined> => {
+  if (protection === "proconnect") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (proConnectMiddleware as any)(request);
+  }
+  if (protection === "password") {
+    return protectByPassword(request) ?? NextResponse.next();
+  }
+  if (protection === "either") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proConnectResult = await (proConnectMiddleware as any)(request);
+    if (proConnectResult?.status === 200) {
+      return proConnectResult;
+    }
+    const passwordResult = protectByPassword(request);
+    if (passwordResult) {
+      return passwordResult;
+    }
+    return NextResponse.redirect(new URL(signInRoute, request.url));
+  }
+  return undefined;
+};
 
-  if (isProtected) {
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  const apiMatch = matchApiRoute(request, pathname);
+  if (apiMatch && apiMatch.method === request.method) {
+    return handleProtection(request, apiMatch.protection);
+  }
+
+  if (proConnectProtectedPaths.some((path) => pathname.startsWith(path))) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (proConnectMiddleware as any)(request);
   }
 
-  const passwordResult = protectByPassword(request);
-  if (passwordResult) {
-    return passwordResult;
+  if (pathname.startsWith(passwordProtectedPath)) {
+    const result = protectByPassword(request);
+    if (result) return result;
+  }
+
+  if (pathname === noProtectionPath) {
+    return NextResponse.next();
   }
 
   return NextResponse.next();
@@ -46,10 +88,18 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    // Frontend routes
     "/structures/:path*",
     "/operateurs/:path*",
     "/statistiques/:path*",
     "/ajout-structure/:path*",
     "/mot-de-passe",
+    // API routes
+    "/api/structures",
+    "/api/structures/:id*",
+    "/api/structures/dna/:id*",
+    "/api/files",
+    "/api/files/:id*",
+    "/api/operateurs",
   ],
 };


### PR DESCRIPTION
Problèmes rencontrés et à creuser : utiliser une variable d'environnement comme `process.NEXT_URL` dans un fetch fait disparaître le token ProConnect lors de l'authentification. Quand on retire cette variable d'environnement, une erreur de fetch se produit, et elle vaut `null`...