### PR TITLE
:bug: Fixes #395 - Subventionnee sans cpom table empty dates

### DIFF
--- a/src/app/(authenticated)/structures/[id]/(finances)/GestionBudgetaireSubentionneeSansCpomTable.tsx
+++ b/src/app/(authenticated)/structures/[id]/(finances)/GestionBudgetaireSubentionneeSansCpomTable.tsx
@@ -7,9 +7,24 @@ import dayjs from "dayjs";
 export const GestionBudgetaireSubventionneeSansCpomTable = (): ReactElement => {
   const { structure } = useStructureContext();
 
+  const budgets = structure?.budgets?.filter((budget) => {
+    return (
+      budget.dotationDemandee ||
+      budget.dotationAccordee ||
+      budget.totalProduits ||
+      budget.totalCharges ||
+      budget.totalChargesProposees ||
+      budget.cumulResultatsNetsCPOM ||
+      budget.repriseEtat ||
+      budget.affectationReservesFondsDedies ||
+      budget.fondsDedies ||
+      budget.commentaire
+    );
+  });
+
   const primaryHeadings = [
     { title: "BUDGET EXÉCUTOIRE DE LA STRUCTURE", colSpan: 2 },
-    { title: "COMPTE ADMINISTRATIF DE LA STRUCTURE", colSpan: 6 },
+    { title: "COMPTE ADMINISTRATIF DE LA STRUCTURE", colSpan: 7 },
   ];
 
   const secondaryHeadings = [
@@ -38,7 +53,7 @@ export const GestionBudgetaireSubventionneeSansCpomTable = (): ReactElement => {
   const computeCumulFondsDedies = (date: Date) => {
     // TODO : use budgets first fonds dediés
     let cumulFondsDedies = 0;
-    structure.budgets?.forEach((budget) => {
+    budgets?.forEach((budget) => {
       if (dayjs(budget.date).isBefore(dayjs(date))) {
         cumulFondsDedies += budget.fondsDedies;
       }
@@ -81,7 +96,7 @@ export const GestionBudgetaireSubventionneeSansCpomTable = (): ReactElement => {
           </tr>
         </thead>
         <tbody>
-          {structure?.budgets?.map((budget) => (
+          {budgets?.map((budget) => (
             <tr key={budget.id} className="border-t-1 border-default-grey">
               <td className="py-2 px-4 text-center text-sm">
                 {new Date(budget.date).getFullYear()}


### PR DESCRIPTION
# :bug: Fix bug d’affichage dans les tableaux de budget

Nous avions un petit bug d'affichage dans les structure subventionnées sans CPOM.
Dans certains cas, une année apparaissait même si toutes ses données étaient vides.

## Pour reproduire : 
Le seeder remplissant toutes les données le bug n'est pas reproductible sans remplir le formulaire de finalisation de la structure (sur des subventionnées sans CPOM du coup).

## Désormais :
	•	si au moins une donnée est remplie → l’année est affichée
	•	si toutes les données sont vides en DB → l’année est masquée