### PR TITLE
:recycle: Refacto places autorisees

### DIFF
--- a/prisma/migrations/20250828121737_old_operateur/migration.sql
+++ b/prisma/migrations/20250828121737_old_operateur/migration.sql
@@ -1,10 +1,2 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `operateur` on the `Structure` table. All the data in the column will be lost.
-  - Added the required column `oldOperateur` to the `Structure` table without a default value. This is not possible if the table is not empty.
-
-*/
--- AlterTable
 ALTER TABLE "public"."Structure" 
 RENAME COLUMN "operateur" TO "oldOperateur"

--- a/prisma/migrations/20250828144939_places_autorisees/migration.sql
+++ b/prisma/migrations/20250828144939_places_autorisees/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."StructureTypologie" 
+RENAME COLUMN "nbPlaces" TO "placesAutorisees"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,7 +119,7 @@ model StructureTypologie {
   structure        Structure @relation(fields: [structureDnaCode], references: [dnaCode], onDelete: Cascade)
   structureDnaCode String
   date             DateTime
-  nbPlaces         Int?
+  placesAutorisees Int?
   pmr              Int
   lgbt             Int
   fvvTeh           Int

--- a/prisma/seeders/structure-typologie.seed.ts
+++ b/prisma/seeders/structure-typologie.seed.ts
@@ -7,14 +7,14 @@ export const createFakeStructureTypologie = ({
   StructureTypologie,
   "id" | "structureDnaCode"
 > => {
-  const nbPlaces = faker.number.int({ min: 0, max: 100 });
+  const placesAutorisees = faker.number.int({ min: 0, max: 100 });
 
   return {
     date: new Date(year, 0, 1, 13),
-    pmr: faker.number.int({ min: 0, max: nbPlaces }),
-    lgbt: faker.number.int({ min: 0, max: nbPlaces }),
-    fvvTeh: faker.number.int({ min: 0, max: nbPlaces }),
-    nbPlaces,
+    pmr: faker.number.int({ min: 0, max: placesAutorisees }),
+    lgbt: faker.number.int({ min: 0, max: placesAutorisees }),
+    fvvTeh: faker.number.int({ min: 0, max: placesAutorisees }),
+    placesAutorisees,
   };
 };
 

--- a/src/app/(authenticated)/structures/[id]/(type-places)/TypePlaceHistory.tsx
+++ b/src/app/(authenticated)/structures/[id]/(type-places)/TypePlaceHistory.tsx
@@ -83,7 +83,7 @@ export const TypePlaceHistory = ({
 
       return [
         year,
-        currentStructureTypologie?.nbPlaces ?? "N/A",
+        currentStructureTypologie?.placesAutorisees ?? "N/A",
         currentStructureTypologie?.pmr ?? "N/A",
         currentStructureTypologie?.lgbt ?? "N/A",
         currentStructureTypologie?.fvvTeh ?? "N/A",

--- a/src/app/(authenticated)/structures/[id]/finalisation/03-type-places/FinalisationTypePlacesForm.tsx
+++ b/src/app/(authenticated)/structures/[id]/finalisation/03-type-places/FinalisationTypePlacesForm.tsx
@@ -31,7 +31,7 @@ export default function FinalisationTypePlacesForm({
     typologies: structure?.structureTypologies?.map((typologie) => ({
       id: typologie.id,
       date: typologie.date,
-      nbPlaces: typologie.nbPlaces,
+      placesAutorisees: typologie.placesAutorisees,
       pmr: typologie.pmr,
       lgbt: typologie.lgbt,
       fvvTeh: typologie.fvvTeh,

--- a/src/app/(authenticated)/structures/[id]/finalisation/03-type-places/validation/finalisationTypePlacesSchema.ts
+++ b/src/app/(authenticated)/structures/[id]/finalisation/03-type-places/validation/finalisationTypePlacesSchema.ts
@@ -8,7 +8,7 @@ export const finalisationTypePlacesSchema = z
     typologies: z.array(
       z.object({
         id: z.number(),
-        nbPlaces: z.union([
+        placesAutorisees: z.union([
           z
             .string()
             .min(1, { message: "Nombre de places requis" })

--- a/src/app/(password-protected)/ajout-structure/[dnaCode]/05-verification/components/TypePlaces.tsx
+++ b/src/app/(password-protected)/ajout-structure/[dnaCode]/05-verification/components/TypePlaces.tsx
@@ -27,7 +27,7 @@ export const TypePlaces = () => {
         >
           <td className="align-middle py-4">{year}</td>
           <td className="!py-4">
-            {localStorageValues?.typologies?.[index]?.autorisees}
+            {localStorageValues?.typologies?.[index]?.placesAutorisees}
           </td>
           <td className="!py-1">
             {localStorageValues?.typologies?.[index]?.pmr}

--- a/src/app/(password-protected)/ajout-structure/forms/FormTypePlaces.tsx
+++ b/src/app/(password-protected)/ajout-structure/forms/FormTypePlaces.tsx
@@ -86,8 +86,8 @@ export default function FormTypePlaces() {
                   <td className="align-middle py-4">{year}</td>
                   <td className="!py-4">
                     <InputWithValidation
-                      name={`typologies.${index}.autorisees`}
-                      id={`typologies.${index}.autorisees`}
+                      name={`typologies.${index}.placesAutorisees`}
+                      id={`typologies.${index}.placesAutorisees`}
                       control={control}
                       type="number"
                       min={0}

--- a/src/app/(password-protected)/ajout-structure/validation/typePlacesSchema.ts
+++ b/src/app/(password-protected)/ajout-structure/validation/typePlacesSchema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export type PlacesFormValues = z.infer<typeof PlacesSchema>;
 export const PlacesSchema = z.object({
-  autorisees: z.preprocess(
+  placesAutorisees: z.preprocess(
     (val) => (val === "" ? undefined : Number(val)),
     z.number()
   ),

--- a/src/app/api/structures/structure.schema.ts
+++ b/src/app/api/structures/structure.schema.ts
@@ -40,7 +40,7 @@ const contactSchema = z.object({
 
 const structureTypologieSchema = z.object({
   date: z.coerce.date({ message: "La date de la typologie est requise" }),
-  // TODO : ajouter nbPlaces
+  placesAutorisees: z.number().int(),
   pmr: z.number().int(),
   lgbt: z.number().int(),
   fvvTeh: z.number().int(),
@@ -131,7 +131,7 @@ const controleSchema = z.object({
 
 const updateStructureTypologieSchema = z.object({
   id: z.number().optional(),
-  nbPlaces: z.number().int(),
+  placesAutorisees: z.number().int(),
   pmr: z.number().int(),
   lgbt: z.number().int(),
   fvvTeh: z.number().int(),

--- a/src/app/api/structures/structure.types.ts
+++ b/src/app/api/structures/structure.types.ts
@@ -51,7 +51,7 @@ type CreateContact = {
 
 type CreateStructureTypologie = {
   date: Date;
-  //TODO : add nbPlaces
+  placesAutorisees: number;
   pmr: number;
   lgbt: number;
   fvvTeh: number;
@@ -99,7 +99,7 @@ export type UpdateContact = CreateContact & { id?: number };
 export type UpdateBudget = CreateBudget & { id?: number };
 export type UpdateStructureTypologie = {
   id?: number;
-  nbPlaces: number;
+  placesAutorisees: number;
   pmr: number;
   lgbt: number;
   fvvTeh: number;

--- a/src/app/components/forms/fieldsets/structure/FieldSetTypePlaces.tsx
+++ b/src/app/components/forms/fieldsets/structure/FieldSetTypePlaces.tsx
@@ -59,8 +59,8 @@ export const FieldSetTypePlaces = () => {
             />
             <td className="!py-4">
               <InputWithValidation
-                name={`typologies.${index}.nbPlaces`}
-                id={`typologies.${index}.nbPlaces`}
+                name={`typologies.${index}.placesAutorisees`}
+                id={`typologies.${index}.placesAutorisees`}
                 control={control}
                 type="number"
                 min={0}

--- a/src/app/hooks/useStructures.ts
+++ b/src/app/hooks/useStructures.ts
@@ -91,7 +91,7 @@ export const useStructures = (): UseStructureResult => {
       newOperateur: values.newOperateur,
       filiale: values.filiale,
       type: values.type,
-      nbPlaces: Number(values.typologies?.[0].autorisees),
+      nbPlaces: Number(values.typologies?.[0].placesAutorisees),
       adresseAdministrative: values.adresseAdministrative,
       codePostalAdministratif: values.codePostalAdministratif,
       communeAdministrative: values.communeAdministrative,
@@ -119,7 +119,7 @@ export const useStructures = (): UseStructureResult => {
       ),
       typologies: values.typologies?.map((typologie) => ({
         ...typologie,
-        autorisees: Number(typologie.autorisees),
+        placesAutorisees: Number(typologie.placesAutorisees),
         pmr: Number(typologie.pmr),
         lgbt: Number(typologie.lgbt),
         fvvTeh: Number(typologie.fvvTeh),

--- a/src/types/structure-typologie.type.ts
+++ b/src/types/structure-typologie.type.ts
@@ -2,7 +2,7 @@ export type StructureTypologie = {
   id: number;
   structureDnaCode: string;
   date: Date;
-  nbPlaces: number;
+  placesAutorisees: number;
   pmr: number;
   lgbt: number;
   fvvTeh: number;


### PR DESCRIPTION
⚔️ Le plan de bataille de la refacto :
-  :white_check_mark: Dans `StructureTypologie`, renommer `nbPlaces` en `placesAutorisees`
- :white_check_mark: A la création d'une structure, stocker le nombre de places autorisées dans `placesAutorisees` de `StructureTypologie`
- **(Optionnel ?)** Transférer nbPlacesTotal de `AdresseTypologie` vers `Adresse`
- Copier `nbPlaces` de `Structure` dans `placesAutorisees` de `StructureTypologie` sur l'entrée qui a la date de l'année courante (2025)
- Remplacer tous les `structure.nbPlaces` en `structure.typologies[2025].placesAutorisees`
- Supprimer `nbPlaces` de `Structure`


Closes https://github.com/betagouv/place-asile/issues/332
Closes https://github.com/betagouv/place-asile/issues/353
Closes https://github.com/betagouv/place-asile/issues/411