### PR TITLE
:recycle: Refactor type places

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,7 +97,7 @@ model AdresseTypologie {
   id             Int      @id @default(autoincrement())
   adresse        Adresse  @relation(fields: [adresseId], references: [id], onDelete: Cascade)
   adresseId      Int
-  nbPlacesTotal  Int
+  nbPlacesTotal  Int // TODO :renommer en places autorisées
   date           DateTime
   qpv            Int
   logementSocial Int

--- a/prisma/seeders/structure.seed.ts
+++ b/prisma/seeders/structure.seed.ts
@@ -51,7 +51,8 @@ const createFakeStructure = ({
     // TODO : à gérer quand les filiales d'opérateurs seront en DB
     filiale: "",
     type,
-    nbPlaces: faker.number.int(100),
+    // TODO : remove, deprecated
+    nbPlaces: -1,
     adresseAdministrative: faker.location.streetAddress(),
     communeAdministrative: faker.location.city(),
     codePostalAdministratif: faker.location.zipCode(),

--- a/src/app/(authenticated)/structures/StructureMarker.tsx
+++ b/src/app/(authenticated)/structures/StructureMarker.tsx
@@ -19,7 +19,7 @@ export const StructureMarker = ({
   operateur,
   filiale,
   type,
-  nbPlaces,
+  placesAutorisees,
   repartition,
   nom,
   commune,
@@ -59,7 +59,7 @@ export const StructureMarker = ({
           <strong className="fr-pr-2w">
             {type} - {getOperateurLabel(filiale, operateur)}
           </strong>
-          {nbPlaces} places
+          {placesAutorisees} places
         </div>
         <div className="text-title-blue-france">
           {nom ? `${nom}, ` : ""}
@@ -102,7 +102,7 @@ type Props = {
   operateur: string | null | undefined;
   filiale: string | null;
   type: StructureType;
-  nbPlaces: number;
+  placesAutorisees: number | undefined;
   repartition: Repartition;
   nom: string | null;
   commune: string;

--- a/src/app/(authenticated)/structures/StructuresMap.tsx
+++ b/src/app/(authenticated)/structures/StructuresMap.tsx
@@ -17,7 +17,7 @@ const StructuresMap = ({ structures }: Props): ReactElement => {
           operateur={structure.operateur?.name}
           filiale={structure.filiale}
           type={structure.type}
-          nbPlaces={structure.nbPlaces}
+          placesAutorisees={structure.structureTypologies?.[0].placesAutorisees}
           repartition={getRepartition(structure)}
           nom={structure.nom}
           commune={structure.communeAdministrative}

--- a/src/app/(authenticated)/structures/StructuresTable.tsx
+++ b/src/app/(authenticated)/structures/StructuresTable.tsx
@@ -69,7 +69,7 @@ export const StructuresTable = ({
             <td>{structure.dnaCode}</td>
             <td>{structure.type}</td>
             <td>{getOperateurLabel(structure.filiale, structure.operateur?.name)}</td>
-            <td>{structure.nbPlaces}</td>
+            <td>{structure.structureTypologies?.[0].placesAutorisees}</td>
             <td>
               <RepartitionBadge repartition={getRepartition(structure)} />
             </td>

--- a/src/app/(authenticated)/structures/[id]/(header)/StructureHeader.tsx
+++ b/src/app/(authenticated)/structures/[id]/(header)/StructureHeader.tsx
@@ -43,7 +43,7 @@ export function StructureHeader(): ReactElement | null {
     type,
     filiale,
     operateur,
-    nbPlaces,
+    structureTypologies,
     nom,
     communeAdministrative,
     departementAdministratif,
@@ -70,7 +70,7 @@ export function StructureHeader(): ReactElement | null {
             </h2>
             <h3 className="text-title-blue-france fr-h6 mb-0">
               <strong className="pr-2">
-                {type}, {getOperateurLabel(filiale, operateur?.name)}, {nbPlaces}{" "}
+                {type}, {getOperateurLabel(filiale, operateur?.name)}, {structureTypologies?.[0].placesAutorisees}{" "}
                 places
               </strong>
               <span className="pr-2">{" – "}</span>

--- a/src/app/(authenticated)/structures/[id]/(type-places)/DefaultTypePlaceBlock.tsx
+++ b/src/app/(authenticated)/structures/[id]/(type-places)/DefaultTypePlaceBlock.tsx
@@ -16,11 +16,12 @@ export const DefaultTypePlaceBlock = (): ReactElement => {
   const { structure } = useStructureContext();
 
   const {
-    nbPlaces: placesAutorisees,
     placesACreer,
     placesAFermer,
     echeancePlacesACreer,
     echeancePlacesAFermer,
+    structureTypologies,
+    adresses,
   } = structure;
 
   return (
@@ -28,7 +29,7 @@ export const DefaultTypePlaceBlock = (): ReactElement => {
       <div className="flex">
         <div className="pr-4">
           <InformationCard
-            primaryInformation={placesAutorisees}
+            primaryInformation={structureTypologies?.[0].placesAutorisees || "N/A"}
             secondaryInformation="places autorisées"
           />
         </div>
@@ -53,18 +54,18 @@ export const DefaultTypePlaceBlock = (): ReactElement => {
       </div>
       <div className="pt-3 flex">
         <TypePlaceCharts
-          placesAutorisees={placesAutorisees}
-          placesPmr={structure?.structureTypologies?.[0]?.pmr || 0}
-          placesLgbt={structure?.structureTypologies?.[0]?.lgbt || 0}
-          placesFvvTeh={structure?.structureTypologies?.[0]?.fvvTeh || 0}
+          placesAutorisees={structureTypologies?.[0]?.placesAutorisees || 0}
+          placesPmr={structureTypologies?.[0]?.pmr || 0}
+          placesLgbt={structureTypologies?.[0]?.lgbt || 0}
+          placesFvvTeh={structureTypologies?.[0]?.fvvTeh || 0}
           placesQPV={getCurrentPlacesQpv(structure)}
           placesLogementsSociaux={getCurrentPlacesLogementsSociaux(structure)}
         />
       </div>
       <div className="pt-3">
         <TypePlaceHistory
-          adresses={structure.adresses || []}
-          structureTypologies={structure.structureTypologies || []}
+          adresses={adresses || []}
+          structureTypologies={structureTypologies || []}
         />
       </div>
     </Block>

--- a/src/app/(authenticated)/structures/[id]/(type-places)/PrahdaTypePlaceBlock.tsx
+++ b/src/app/(authenticated)/structures/[id]/(type-places)/PrahdaTypePlaceBlock.tsx
@@ -12,7 +12,7 @@ export const PrahdaTypePlaceBlock = (): ReactElement => {
   return (
     <Block title="Type de places" iconClass="fr-icon-map-pin-2-line">
       <InformationCard
-        primaryInformation={structure.nbPlaces}
+        primaryInformation={structure.structureTypologies?.[0].placesAutorisees || "N/A"}
         secondaryInformation="places autorisées"
       />
     </Block>

--- a/src/app/api/structures/structure.repository.ts
+++ b/src/app/api/structures/structure.repository.ts
@@ -31,7 +31,12 @@ export const findAll = async (): Promise<Structure[]> => {
           },
         },
       },
-      operateur: true
+      operateur: true,
+      structureTypologies: {
+        orderBy: {
+          date: 'desc'
+        }
+      }
     },
   });
 };
@@ -154,7 +159,7 @@ export const createOne = async (
       latitude: Prisma.Decimal(coordinates.latitude || 0),
       longitude: Prisma.Decimal(coordinates.longitude || 0),
       type: convertToStructureType(structure.type),
-      nbPlaces: structure.nbPlaces,
+      nbPlaces: -1,
       adresseAdministrative: structure.adresseAdministrative,
       codePostalAdministratif: structure.codePostalAdministratif,
       communeAdministrative: structure.communeAdministrative,

--- a/src/app/api/structures/structure.schema.ts
+++ b/src/app/api/structures/structure.schema.ts
@@ -57,11 +57,6 @@ export const structureCreationSchema = z.object({
   operateur: z.object({ id: z.number(), name: z.string() }),
   filiale: z.string().optional(),
   type: z.nativeEnum(StructureType),
-  nbPlaces: z
-    .number()
-    .int()
-    .positive()
-    .min(1, "Le nombre de places autorisées est requis"),
   adresseAdministrative: z
     .string()
     .min(1, "L'adresse administrative est requise"),
@@ -142,12 +137,6 @@ export const structureUpdateSchema = z.object({
   operateur: z.object({ id: z.number(), name: z.string() }).optional(),
   filiale: z.string().optional(),
   type: z.nativeEnum(StructureType).optional(),
-  nbPlaces: z
-    .number()
-    .int()
-    .positive()
-    .min(1, "Le nombre de places autorisées est requis")
-    .optional(),
   adresseAdministrative: z
     .string()
     .min(1, "L'adresse administrative est requise")

--- a/src/app/api/structures/structure.types.ts
+++ b/src/app/api/structures/structure.types.ts
@@ -3,7 +3,6 @@ export type CreateStructure = {
   operateur: CreateOperateur;
   filiale?: string;
   type: string;
-  nbPlaces: number;
   adresseAdministrative: string;
   codePostalAdministratif: string;
   communeAdministrative: string;
@@ -130,7 +129,6 @@ export type UpdateStructure = {
   operateur?: UpdateOperateur;
   filiale?: string;
   type?: string;
-  nbPlaces?: number;
   adresseAdministrative?: string;
   codePostalAdministratif?: string;
   communeAdministrative?: string;

--- a/src/app/hooks/useStructures.ts
+++ b/src/app/hooks/useStructures.ts
@@ -91,7 +91,6 @@ export const useStructures = (): UseStructureResult => {
       operateur: values.operateur,
       filiale: values.filiale,
       type: values.type,
-      nbPlaces: Number(values.typologies?.[0].placesAutorisees),
       adresseAdministrative: values.adresseAdministrative,
       codePostalAdministratif: values.codePostalAdministratif,
       communeAdministrative: values.communeAdministrative,

--- a/src/types/structure-typologie.type.ts
+++ b/src/types/structure-typologie.type.ts
@@ -1,6 +1,5 @@
 export type StructureTypologie = {
   id: number;
-  structureDnaCode: string;
   date: Date;
   placesAutorisees: number;
   pmr: number;

--- a/src/types/structure.type.ts
+++ b/src/types/structure.type.ts
@@ -15,7 +15,6 @@ export type Structure = {
   dnaCode: string;
   filiale: string | null;
   type: StructureType;
-  nbPlaces: number;
   placesACreer: number | null;
   placesAFermer: number | null;
   echeancePlacesACreer: Date | null;

--- a/tests/(authenticated)/structures/StructuresTable.test.tsx
+++ b/tests/(authenticated)/structures/StructuresTable.test.tsx
@@ -3,6 +3,7 @@ import { StructuresTable } from "../../../src/app/(authenticated)/structures/Str
 import { createStructure } from "../../test-utils/structure.factory";
 import { Structure } from "@/types/structure.type";
 import { createAdresse } from "../../test-utils/adresse.factory";
+import { createStructureTypologie } from "../../test-utils/structure-typologie.factory";
 
 describe("StructuresTable", () => {
   it("should show table headings and content elements when rendered", () => {
@@ -10,9 +11,12 @@ describe("StructuresTable", () => {
     const adresse1 = createAdresse({});
     const adresse2 = createAdresse({});
     const adresse3 = createAdresse({});
-    const structure1 = createStructure({});
-    const structure2 = createStructure({});
-    const structure3 = createStructure({});
+    const structureTypologies1 = [createStructureTypologie()]
+    const structureTypologies2 = [createStructureTypologie()]
+    const structureTypologies3 = [createStructureTypologie()]
+    const structure1 = createStructure({structureTypologies: structureTypologies1});
+    const structure2 = createStructure({structureTypologies: structureTypologies2});
+    const structure3 = createStructure({structureTypologies: structureTypologies3});
     structure1.adresses = [adresse1];
     structure2.adresses = [adresse2];
     structure3.adresses = [adresse3];
@@ -43,7 +47,7 @@ describe("StructuresTable", () => {
     expect(firstStructureCells[0]).toHaveAccessibleName("C0001");
     expect(firstStructureCells[1]).toHaveAccessibleName("CADA");
     expect(firstStructureCells[2]).toHaveAccessibleName("Adoma");
-    expect(firstStructureCells[3]).toHaveAccessibleName("5");
+    expect(firstStructureCells[3]).toHaveAccessibleName("10");
     expect(firstStructureCells[4]).toHaveAccessibleName("Diffus");
     expect(firstStructureCells[5]).toHaveAccessibleName("Paris");
     expect(firstStructureCells[6]).toHaveAccessibleName(
@@ -56,7 +60,7 @@ describe("StructuresTable", () => {
     expect(secondStructureCells[0]).toHaveAccessibleName("C0001");
     expect(secondStructureCells[1]).toHaveAccessibleName("CADA");
     expect(secondStructureCells[2]).toHaveAccessibleName("Adoma");
-    expect(secondStructureCells[3]).toHaveAccessibleName("5");
+    expect(secondStructureCells[3]).toHaveAccessibleName("10");
     expect(secondStructureCells[4]).toHaveAccessibleName("Diffus");
     expect(secondStructureCells[5]).toHaveAccessibleName("Paris");
     expect(firstStructureCells[6]).toHaveAccessibleName(
@@ -69,7 +73,7 @@ describe("StructuresTable", () => {
     expect(thirdStructureCells[0]).toHaveAccessibleName("C0001");
     expect(thirdStructureCells[1]).toHaveAccessibleName("CADA");
     expect(thirdStructureCells[2]).toHaveAccessibleName("Adoma");
-    expect(thirdStructureCells[3]).toHaveAccessibleName("5");
+    expect(thirdStructureCells[3]).toHaveAccessibleName("10");
     expect(thirdStructureCells[4]).toHaveAccessibleName("Diffus");
     expect(thirdStructureCells[5]).toHaveAccessibleName("Paris");
     expect(firstStructureCells[6]).toHaveAccessibleName(

--- a/tests/test-utils/structure-typologie.factory.ts
+++ b/tests/test-utils/structure-typologie.factory.ts
@@ -1,0 +1,12 @@
+import { StructureTypologie } from "@/types/structure-typologie.type";
+
+export const createStructureTypologie = (): StructureTypologie => {
+  return {
+    id: 1,
+    date: new Date("01/01/2023"),
+    fvvTeh: 5,
+    lgbt: 4,
+    placesAutorisees: 10,
+    pmr: 3,
+  };
+};

--- a/tests/test-utils/structure.factory.ts
+++ b/tests/test-utils/structure.factory.ts
@@ -1,4 +1,5 @@
 import { Adresse } from "@/types/adresse.type";
+import { StructureTypologie } from "@/types/structure-typologie.type";
 import {
   PublicType,
   Structure,
@@ -9,13 +10,13 @@ import { LatLngTuple } from "leaflet";
 
 export const createStructure = ({
   adresseAdministrative,
-  nbPlaces,
   adresses,
   type,
   finessCode,
   publicType,
   state,
   cpom,
+  structureTypologies,
 }: CreateStructuresArgs): Structure => {
   return {
     id: 1,
@@ -23,7 +24,6 @@ export const createStructure = ({
     operateur: { structureDnaCode: "C0001", id: 1, name: "Adoma" },
     filiale: null,
     type: type ?? StructureType.CADA,
-    nbPlaces: nbPlaces ?? 5,
     placesACreer: 3,
     placesAFermer: 2,
     echeancePlacesACreer: new Date("01/02/2026"),
@@ -52,12 +52,13 @@ export const createStructure = ({
     adresses: adresses ?? [],
     notes: "Note 1",
     state: state ?? StructureState.A_FINALISER,
+    structureTypologies: structureTypologies ?? []
   };
 };
 
 type CreateStructuresArgs = {
   adresseAdministrative?: string;
-  nbPlaces?: number;
+  structureTypologies?: StructureTypologie[]
   adresses?: Adresse[];
   type?: StructureType;
   finessCode?: string;


### PR DESCRIPTION
⚔️ La suite du plan de bataille de la refacto :

✅ Dans StructureTypologie, renommer nbPlaces en placesAutorisees
✅ A la création d'une structure, stocker le nombre de places autorisées dans placesAutorisees de StructureTypologie
:x: (Optionnel ?) Transférer nbPlacesTotal de AdresseTypologie vers Adresse => On laisse de côté pour le moment : faible valeur du refacto pour pas mal de complexité de migration
✅ Copier nbPlaces de Structure dans placesAutorisees de StructureTypologie sur l'entrée qui a la date de l'année courante (2025)
✅ Remplacer tous les structure.nbPlaces en structure.typologies[2025].placesAutorisees
Supprimer nbPlaces de Structure

Closes https://github.com/betagouv/place-asile/issues/362
Closes https://github.com/betagouv/place-asile/issues/330