### PR TITLE
:tada: Quality form validation

### DIFF
--- a/src/app/(authenticated)/structures/[id]/finalisation/05-qualite/FinalisationQualiteForm.tsx
+++ b/src/app/(authenticated)/structures/[id]/finalisation/05-qualite/FinalisationQualiteForm.tsx
@@ -2,6 +2,7 @@
 import Notice from "@codegouvfr/react-dsfr/Notice";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
+import { UseFormReturn } from "react-hook-form";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
@@ -15,7 +16,6 @@ import { isStructureSubventionnee } from "@/app/utils/structure.util";
 import {
   DdetsFileUploadCategory,
   DdetsFileUploadCategoryType,
-  FileUpload,
   zDdetsFileUploadCategory,
 } from "@/types/file-upload.type";
 import { StructureState } from "@/types/structure.type";
@@ -23,7 +23,10 @@ import { StructureState } from "@/types/structure.type";
 import { useStructureContext } from "../../context/StructureClientContext";
 import { getCurrentStepData } from "../components/Steps";
 import UploadsByCategory from "./components/UploadsByCategory";
-import { finalisationQualiteSchemaSimple } from "./validation/FinalisationQualiteSchema";
+import {
+  fileUploadSchema,
+  finalisationQualiteSchemaSimple,
+} from "./validation/FinalisationQualiteSchema";
 
 export enum FileMetaData {
   DATE_TYPE,
@@ -61,20 +64,7 @@ export const FinalisationQualiteForm = ({
     return true;
   });
 
-  const categoriesDisplayRules: Record<
-    (typeof DdetsFileUploadCategory)[number],
-    {
-      categoryShortName: string;
-      title: string;
-      canAddFile: boolean;
-      canAddAvenant: boolean;
-      isOptional: boolean;
-      fileMetaData: FileMetaData;
-      documentLabel: string;
-      addFileButtonLabel: string;
-      notice?: string | React.ReactElement;
-    }
-  > = {
+  const categoriesDisplayRules: CategoryDisplayRulesType = {
     INSPECTION_CONTROLE: {
       categoryShortName: "",
       title: "Inspections-contrôles",
@@ -145,34 +135,79 @@ export const FinalisationQualiteForm = ({
   };
 
   const handleSubmit = async (
-    data: z.infer<typeof finalisationQualiteSchemaSimple>
+    data: z.infer<typeof finalisationQualiteSchemaSimple>,
+    methods: UseFormReturn<z.infer<typeof finalisationQualiteSchemaSimple>>
   ) => {
     setState("loading");
-
-    const fileUploads = data.fileUploads?.filter((fileUpload) => {
-      return fileUpload.key !== undefined;
-    }) as FileUpload[];
-
-    // TODO : gérer les erreurs sur champs obligatoires avant envoi au back
-    const updatedStructure = await updateAndRefreshStructure(
-      structure.id,
-      {
-        fileUploads: fileUploads,
-        dnaCode: structure.dnaCode,
-      },
-      setStructure
+    const setError = methods.setError;
+    const fileUploads = data.fileUploads;
+    const requiredCategories = Object.keys(categoriesDisplayRules).filter(
+      (category) =>
+        !categoriesDisplayRules[category as keyof typeof categoriesDisplayRules]
+          .isOptional
     );
-    if (updatedStructure === "OK") {
-      router.push(nextRoute);
+
+    let firstErrorIndex: number | null = null;
+
+    const missingRequiredUploads = fileUploads?.flatMap((fileUpload, index) => {
+      if (requiredCategories.includes(fileUpload.category) && !fileUpload.key) {
+        return { fileUpload, index };
+      }
+      return [];
+    });
+
+    if (missingRequiredUploads?.length) {
+      firstErrorIndex = missingRequiredUploads[0].index;
+
+      missingRequiredUploads.forEach(({ index }) => {
+        setError(`fileUploads.${index}.key` as const, {
+          type: "custom",
+          message: "Veuillez sélectionner au moins un document.",
+        });
+      });
+    }
+
+    if (firstErrorIndex !== null) {
+      setTimeout(() => {
+        const errorField = document.querySelector(
+          `[name="fileUploads.${firstErrorIndex}.key"]`
+        );
+        if (errorField instanceof HTMLElement) {
+          errorField.focus();
+          errorField.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }, 100);
+
+      return;
     } else {
-      setState("error");
-      setBackendError(updatedStructure?.toString());
-      throw new Error(updatedStructure?.toString());
+      const filteredFileUploads = fileUploads?.filter((fileUpload) => {
+        return fileUpload.key !== undefined;
+      }) as z.infer<typeof fileUploadSchema>[];
+
+      const updatedStructure = await updateAndRefreshStructure(
+        structure.id,
+        {
+          fileUploads: filteredFileUploads,
+          dnaCode: structure.dnaCode,
+        },
+        setStructure
+      );
+      if (updatedStructure === "OK") {
+        router.push(nextRoute);
+      } else {
+        setState("error");
+        setBackendError(updatedStructure?.toString());
+        throw new Error(updatedStructure?.toString());
+      }
     }
   };
 
   const filteredFileUploads = structure.fileUploads?.filter(
     (fileUpload) =>
+      fileUpload?.category &&
+      categoriesToDisplay.includes(
+        fileUpload.category as DdetsFileUploadCategoryType[number]
+      )
       fileUpload?.category &&
       categoriesToDisplay.includes(
         fileUpload.category as DdetsFileUploadCategoryType[number]
@@ -306,3 +341,18 @@ export const FinalisationQualiteForm = ({
     </FormWrapper>
   );
 };
+
+type CategoryDisplayRulesType = Record<
+  (typeof DdetsFileUploadCategory)[number],
+  {
+    categoryShortName: string;
+    title: string;
+    canAddFile: boolean;
+    canAddAvenant: boolean;
+    isOptional: boolean;
+    fileMetaData: FileMetaData;
+    documentLabel: string;
+    addFileButtonLabel: string;
+    notice?: string | React.ReactElement;
+  }
+>;

--- a/src/app/(authenticated)/structures/[id]/finalisation/05-qualite/FinalisationQualiteForm.tsx
+++ b/src/app/(authenticated)/structures/[id]/finalisation/05-qualite/FinalisationQualiteForm.tsx
@@ -208,10 +208,6 @@ export const FinalisationQualiteForm = ({
       categoriesToDisplay.includes(
         fileUpload.category as DdetsFileUploadCategoryType[number]
       )
-      fileUpload?.category &&
-      categoriesToDisplay.includes(
-        fileUpload.category as DdetsFileUploadCategoryType[number]
-      )
   );
 
   const defaultValuesFromDb = (filteredFileUploads || [])?.map((fileUpload) => {

--- a/src/app/components/forms/FormWrapper.tsx
+++ b/src/app/components/forms/FormWrapper.tsx
@@ -9,7 +9,6 @@ import { ReactNode, useEffect, useState } from "react";
 import {
   FieldErrors,
   FormProvider as HookFormProvider,
-  SubmitHandler,
   useForm,
   UseFormReturn,
   useWatch,
@@ -32,7 +31,10 @@ type FormWrapperProps<TSchema extends z.ZodTypeAny> = {
   schema: TSchema;
   localStorageKey?: string;
   children: ReactNode | ((form: UseFormReturn<z.infer<TSchema>>) => ReactNode);
-  onSubmit?: SubmitHandler<z.infer<TSchema>>;
+  onSubmit?: (
+    data: z.infer<TSchema>,
+    methods: UseFormReturn<z.infer<TSchema>>
+  ) => void | Promise<void>;
   onError?: (errors: FieldErrors<z.infer<TSchema>>) => void;
   mode?: "onChange" | "onBlur" | "onSubmit" | "onTouched" | "all";
   className?: string;
@@ -112,7 +114,7 @@ export default function FormWrapper<TSchema extends z.ZodTypeAny>({
     }
   };
 
-  const defaultSubmitHandler: SubmitHandler<z.infer<TSchema>> = (data) => {
+  const defaultSubmitHandler = (data: z.infer<TSchema>) => {
     console.log("Form submitted successfully with data:", data);
     if (nextRoute) {
       try {
@@ -145,7 +147,7 @@ export default function FormWrapper<TSchema extends z.ZodTypeAny>({
       <FormProvider formMethods={methods}>
         <form
           onSubmit={handleSubmit(
-            onSubmit || defaultSubmitHandler,
+            (data) => (onSubmit || defaultSubmitHandler)(data, methods),
             handleFormErrors
           )}
           className={cn(


### PR DESCRIPTION
# 🎉 Validation du formulaire de qualitay

Yo @Alezco  ! J'ai ajouté la validation côté client pour le formulaire de qualité des structures.

## 🧠 Comment ça marche

Le formulaire vérifie maintenant que toutes les catégories non-optionnelles ont au moins un document associé. Si ce n'est pas le cas, l'utilisateur est averti et le focus est automatiquement placé sur le premier champ en erreur.

## 🚀 Ce qui a été fait :

- Mapping des catégories obligatoires en reprenant les règles d'affichage
- Récupération des champs uploads vides mais obligatoires
- Evol du form Wrapper pour pouvoir passer les méthodes hook form dans la fonction handleSubmit (truc de ninja bro')

`<IF on a des erreurs : >`
- Blocage de l'envoi form si il existe des champs en erreur
- Passage de champs en erreur
- Scroll auto jusqu'au premier champ "errorisé"

`<ELSE : >`
- Filtrage des uploads vides avant envoi au backend

## 🔍 Pour tester

- Essayer de soumettre le formulaire sans ajouter de documents dans les catégories obligatoires
- Vérifier que les messages d'erreur s'affichent correctement
- S'assurer que le focus se place bien sur le premier champ en erreur

En attendant je passe à la suite.

Merci pour la review 😘