### PR TITLE
:sparkles: Hide sticky header on scroll down

### DIFF
--- a/src/app/(authenticated)/(with-menu)/cpoms/[id]/_components/CpomHeader.tsx
+++ b/src/app/(authenticated)/(with-menu)/cpoms/[id]/_components/CpomHeader.tsx
@@ -7,6 +7,7 @@ import { ReactElement, useEffect, useRef } from "react";
 
 import { NavigationMenu } from "@/app/components/common/NavigationMenu";
 import { useHeaderHeight } from "@/app/hooks/useHeaderHeight";
+import { useHideOnScroll } from "@/app/hooks/useHideOnScroll";
 import { formatCpomName } from "@/app/utils/cpom.util";
 import { getYearFromDate } from "@/app/utils/date.util";
 
@@ -16,6 +17,7 @@ export const CpomHeader = (): ReactElement | null => {
   const { cpom } = useCpomContext();
 
   const { headerRef } = useHeaderHeight();
+  const { isHidden } = useHideOnScroll();
 
   const router = useRouter();
 
@@ -46,7 +48,12 @@ export const CpomHeader = (): ReactElement | null => {
   };
 
   return cpom ? (
-    <div className="sticky top-0 z-50 bg-lifted-grey" ref={headerRef}>
+    <div
+      className={`sticky top-0 z-50 bg-lifted-grey transition-transform duration-300 ease-in-out ${
+        isHidden ? "-translate-y-full" : "translate-y-0"
+      }`}
+      ref={headerRef}
+    >
       <div className="flex border-b border-b-border-default-grey px-6 py-3 items-center">
         <Button
           className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-s-line"

--- a/src/app/(authenticated)/(with-menu)/operateurs/[id]/_components/OperateurHeader.tsx
+++ b/src/app/(authenticated)/(with-menu)/operateurs/[id]/_components/OperateurHeader.tsx
@@ -6,6 +6,7 @@ import { ReactElement } from "react";
 
 import { NavigationMenu } from "@/app/components/common/NavigationMenu";
 import { useHeaderHeight } from "@/app/hooks/useHeaderHeight";
+import { useHideOnScroll } from "@/app/hooks/useHideOnScroll";
 
 import { useOperateurContext } from "../_context/OperateurClientContext";
 
@@ -14,11 +15,17 @@ export const OperateurHeader = (): ReactElement | null => {
   const pathname = usePathname();
 
   const { headerRef } = useHeaderHeight();
+  const { isHidden } = useHideOnScroll();
 
   const isRootPath = pathname === `/operateurs/${operateur?.id}`;
 
   return operateur ? (
-    <div className="sticky top-0 z-50 bg-lifted-grey" ref={headerRef}>
+    <div
+      className={`sticky top-0 z-50 bg-lifted-grey transition-transform duration-300 ease-in-out ${
+        isHidden ? "-translate-y-full" : "translate-y-0"
+      }`}
+      ref={headerRef}
+    >
       <div className="flex border-b border-b-border-default-grey px-6 py-3 items-center">
         <Link
           className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-s-line"

--- a/src/app/(authenticated)/(with-menu)/structures/[id]/_components/_header/StructureHeader.tsx
+++ b/src/app/(authenticated)/(with-menu)/structures/[id]/_components/_header/StructureHeader.tsx
@@ -9,6 +9,7 @@ import { ReactElement } from "react";
 import { NavigationMenu } from "@/app/components/common/NavigationMenu";
 import { useAgentFormHandling } from "@/app/hooks/useAgentFormHandling";
 import { useHeaderHeight } from "@/app/hooks/useHeaderHeight";
+import { useHideOnScroll } from "@/app/hooks/useHideOnScroll";
 import { getFinalisationFormStatus } from "@/app/utils/finalisationForm.util";
 
 import { useStructureContext } from "../../_context/StructureClientContext";
@@ -35,6 +36,7 @@ export const StructureHeader = (): ReactElement | null => {
     useAgentFormHandling();
 
   const { headerRef } = useHeaderHeight();
+  const { isHidden } = useHideOnScroll();
 
   const pathname = usePathname();
 
@@ -54,7 +56,12 @@ export const StructureHeader = (): ReactElement | null => {
 
   return structure ? (
     <>
-      <div className="sticky top-0 z-50 bg-lifted-grey" ref={headerRef}>
+      <div
+        className={`sticky top-0 z-50 bg-lifted-grey transition-transform duration-300 ease-in-out ${
+          isHidden ? "-translate-y-full" : "translate-y-0"
+        }`}
+        ref={headerRef}
+      >
         <div className="flex border-b border-b-border-default-grey px-6 py-3 items-center">
           <Link
             href="/structures"

--- a/src/app/hooks/useHideOnScroll.ts
+++ b/src/app/hooks/useHideOnScroll.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+
+export const useHideOnScroll = (threshold = 80) => {
+  const [isHidden, setIsHidden] = useState(false);
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+    let ticking = false;
+
+    const onScroll = () => {
+      if (ticking) {
+        return;
+      }
+      ticking = true;
+      window.requestAnimationFrame(() => {
+        const currentY = window.scrollY;
+        const delta = currentY - lastY;
+
+        if (currentY <= threshold) {
+          setIsHidden(false);
+        } else if (delta > 4) {
+          setIsHidden(true);
+        } else if (delta < -4) {
+          setIsHidden(false);
+        }
+
+        lastY = currentY;
+        ticking = false;
+      });
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold]);
+
+  return { isHidden };
+};


### PR DESCRIPTION
## Résumé

Le header sticky des pages détail (`/structures/[id]`, `/operateurs/[id]`, `/cpoms/[id]`) glisse maintenant hors champ lorsqu'on scrolle vers le bas et réapparaît dès qu'on scrolle vers le haut. Cela libère de l'espace vertical à la lecture tout en gardant la navigation rapidement accessible.

## Changements

- Nouveau hook `src/app/hooks/useHideOnScroll.ts` : écoute le scroll de la fenêtre via `requestAnimationFrame`, suit la direction du scroll et expose `isHidden`. Seuil de 80 px en haut de page et marge de ±4 px sur le delta pour éviter le jitter (notamment trackpad macOS).
- Utilisation du hook dans `StructureHeader`, `OperateurHeader` et `CpomHeader` avec une transition Tailwind `transition-transform duration-300 ease-in-out` et `-translate-y-full` / `translate-y-0` sur le `div` racine sticky.

## Choix techniques

- L'élément reste en flux `sticky` : `useHeaderHeight` continue de mesurer la hauteur réelle, la variable CSS `--structure-header-height` reste à jour et les ancres `scroll-margin-header` du `NavigationMenu` ne sont pas affectées.
- `translate` plutôt que démontage/`display:none` : pas de saut de layout, animation fluide.

## Test plan

- [ ] Sur `/structures/[id]` (racine et sous-pages) : scroll vers le bas masque le header, scroll vers le haut le réaffiche.
- [ ] Sur `/operateurs/[id]` : même comportement.
- [ ] Sur `/cpoms/[id]` : même comportement.
- [ ] Cliquer sur les ancres du `NavigationMenu` (Description, Calendrier, …) positionne correctement la section.
- [ ] Aucun jitter au trackpad ; aucun masquage quand on est proche du haut de page.
- [ ] Comportement OK quand `FinalisationHeader` est affiché (structure non finalisée).

Made with [Cursor](https://cursor.com)