### PR TITLE
✨ Add autres actes administratifs to CPOM

### DIFF
--- a/src/app/(authenticated)/(with-menu)/cpoms/[id]/modification/actes-administratifs/page.tsx
+++ b/src/app/(authenticated)/(with-menu)/cpoms/[id]/modification/actes-administratifs/page.tsx
@@ -14,7 +14,6 @@ import { useCpomFormHandling } from "@/app/hooks/useCpomFormHandling";
 import { getCpomDefaultValues } from "@/app/utils/cpom.util";
 import { actesAdministratifsCpomSchema } from "@/schemas/forms/base/cpom.schema";
 import { FetchState } from "@/types/fetch-state.type";
-import { FormKind } from "@/types/global";
 
 import { useCpomContext } from "../../_context/CpomClientContext";
 
@@ -35,7 +34,7 @@ export default function CpomModificationActesAdministratifs() {
   return (
     <>
       <ModificationTitle
-        step="Document de convention du CPOM"
+        step="Actes administratifs"
         handleCancel={() => setShouldOpenModal(true)}
       />
       <FormWrapper
@@ -50,7 +49,7 @@ export default function CpomModificationActesAdministratifs() {
         ]}
         className="border-2 border-solid border-(--text-title-blue-france)"
       >
-        <FieldSetActesAdministratifs formKind={FormKind.MODIFICATION} />
+        <FieldSetActesAdministratifs />
         {saveState === FetchState.ERROR && (
           <SubmitError cpomId={cpom.id} backendError={backendError} />
         )}

--- a/src/app/components/forms/MaxSizeNotice.tsx
+++ b/src/app/components/forms/MaxSizeNotice.tsx
@@ -1,11 +1,16 @@
+import { cn } from "@/app/utils/classname.util";
+
 import { CustomNotice } from "../common/CustomNotice";
 
-export const MaxSizeNotice = () => {
+export const MaxSizeNotice = ({ className }: { className?: string }) => {
   return (
     <CustomNotice
       severity="info"
       title=""
-      className="rounded [&_p]:flex [&_p]:items-center mb-8 w-fit"
+      className={cn(
+        "rounded [&_p]:flex [&_p]:items-center mb-8 w-fit",
+        className
+      )}
       description={
         <>
           Taille maximale par fichier : 10 Mo. Formats supportés : pdf, xls,

--- a/src/app/components/forms/actesAdministratifs/FieldSetActeAdministratif.tsx
+++ b/src/app/components/forms/actesAdministratifs/FieldSetActeAdministratif.tsx
@@ -82,13 +82,15 @@ export default function FieldSetActeAdministratif({
           {title} {isOptional && "(optionnel)"}
         </legend>
       )}
-      {notice && (
+      {typeof notice === "string" ? (
         <CustomNotice
           severity="info"
           title=""
           className="rounded [&_p]:flex [&_p]:items-center w-fit"
           description={<>{notice}</>}
         />
+      ) : (
+        notice
       )}
       {actesOfCategory &&
         actesOfCategory.length > 0 &&

--- a/src/app/components/forms/cpom/DatesAndDocuments.tsx
+++ b/src/app/components/forms/cpom/DatesAndDocuments.tsx
@@ -10,6 +10,7 @@ import { ActeAdministratifFormValues } from "@/schemas/forms/base/acteAdministra
 
 import FieldSetActeAdministratif from "../actesAdministratifs/FieldSetActeAdministratif";
 import InputWithValidation from "../InputWithValidation";
+import { MaxSizeNotice } from "../MaxSizeNotice";
 
 dayjs.extend(customParseFormat);
 
@@ -25,14 +26,19 @@ export const DatesAndDocuments = () => {
   // We use a key to run the useEffect every time the dates change
   const actesDatesKey =
     actesAdministratifs
-      ?.map(
+      ?.filter((a) => a?.category === "CONVENTION")
+      .map(
         (acteAdministratif) =>
           `${acteAdministratif?.startDate ?? ""}-${acteAdministratif?.endDate ?? ""}`
       )
       .join("|") ?? "";
 
   useEffect(() => {
-    const dateEnd = actesAdministratifs.reduce((accumulator, current) => {
+    const conventionActes = actesAdministratifs.filter(
+      (acteAdministratif) => acteAdministratif?.category === "CONVENTION"
+    );
+
+    const dateEnd = conventionActes.reduce((accumulator, current) => {
       if (!current.endDate) {
         return accumulator;
       }
@@ -53,9 +59,8 @@ export const DatesAndDocuments = () => {
     }, "");
 
     const dateStart = formatDateToIsoString(
-      actesAdministratifs.find(
-        (acteAdministratif) => acteAdministratif.startDate
-      )?.startDate
+      conventionActes.find((acteAdministratif) => acteAdministratif.startDate)
+        ?.startDate
     );
 
     setValue("dateEnd", dateEnd);
@@ -82,8 +87,7 @@ export const DatesAndDocuments = () => {
         <FieldSetActeAdministratif
           category="CONVENTION"
           categoryShortName="CPOM"
-          title="CPOM"
-          noTitleLegend={true}
+          title="Contrat CPOM"
           canAddFile={false}
           canAddAvenant={true}
           avenantCanExtendDateEnd={true}
@@ -91,8 +95,21 @@ export const DatesAndDocuments = () => {
           additionalFieldsType={AdditionalFieldsType.DATE_START_END}
           documentLabel="Document"
           addFileButtonLabel="Ajouter un CPOM"
+          notice={<MaxSizeNotice className="mb-0" />}
         />
       </div>
+      <FieldSetActeAdministratif
+        category="AUTRE"
+        categoryShortName="autre"
+        title="Autres documents"
+        canAddFile={true}
+        canAddAvenant={false}
+        isOptional={true}
+        additionalFieldsType={AdditionalFieldsType.NAME}
+        documentLabel="Document"
+        addFileButtonLabel="Ajouter un document"
+        notice={<MaxSizeNotice className="mb-0" />}
+      />
       {errorMessages?.length > 0 && (
         <p className="text-default-error m-0 p-0">
           {errorMessages?.length ? errorMessages[0] : ""}

--- a/src/app/components/forms/cpom/FieldSetActesAdministratifs.tsx
+++ b/src/app/components/forms/cpom/FieldSetActesAdministratifs.tsx
@@ -1,23 +1,10 @@
-import { FormKind } from "@/types/global";
-
-import { MaxSizeNotice } from "../MaxSizeNotice";
 import { DatesAndDocuments } from "./DatesAndDocuments";
 
-export const FieldSetActesAdministratifs = ({ formKind }: Props) => {
+export const FieldSetActesAdministratifs = () => {
   return (
     <fieldset className="flex flex-col gap-6">
-      {formKind !== "modification" && (
-        <legend className="text-xl font-bold mb-4 text-title-blue-france">
-          Document de convention du CPOM
-        </legend>
-      )}
-      <MaxSizeNotice />
       <DatesAndDocuments />
       <hr />
     </fieldset>
   );
-};
-
-type Props = {
-  formKind?: FormKind;
 };

--- a/src/schemas/forms/base/acteAdministratif.schema.ts
+++ b/src/schemas/forms/base/acteAdministratif.schema.ts
@@ -119,7 +119,7 @@ export const acteAdministratifCpomSchema = acteAdministratifSchema.refine(
   }
 );
 
-const filterActesWithKey =
+export const filterActesWithKey =
   (allowedCategories: ActeAdministratifCategory[] = []) =>
   (val: unknown) =>
     Array.isArray(val)

--- a/src/schemas/forms/base/cpom.schema.ts
+++ b/src/schemas/forms/base/cpom.schema.ts
@@ -12,7 +12,7 @@ import { cpomDepartementApiSchema } from "@/schemas/api/cpom.schema";
 import { regionApiSchema } from "@/schemas/api/region.schema";
 import { StructureType } from "@/types/structure.type";
 
-import { acteAdministratifCpomSchema } from "./acteAdministratif.schema";
+import { acteAdministratifCpomSchema, filterActesWithKey } from "./acteAdministratif.schema";
 import { operateurSchema } from "./operateur.schema";
 
 const budgetCpomSchema = z.object({
@@ -80,7 +80,10 @@ export const financesCpomSchema = z.object({
 });
 
 export const actesAdministratifsCpomSchema = z.object({
-  actesAdministratifs: z.array(acteAdministratifCpomSchema),
+  actesAdministratifs: z.preprocess(
+    filterActesWithKey(["CONVENTION"]),
+    z.array(acteAdministratifCpomSchema).optional()
+  ),
 });
 
 export const compositionCpomSchema = z.object({
@@ -129,18 +132,21 @@ export const cpomSchema = descriptionCpomSchema
   )
   .refine(
     (data) => {
-      if (data.actesAdministratifs.length === 0) {
+      if (!data.actesAdministratifs?.length) {
         return true;
       }
-      const convention = data.actesAdministratifs.find(
-        (acteAdministratif) => !acteAdministratif.parentId
+      const convention = data.actesAdministratifs?.find(
+        (acteAdministratif) =>
+          !acteAdministratif.parentId &&
+          !acteAdministratif.parentUuid &&
+          acteAdministratif.category === "CONVENTION"
       );
       if (!convention) {
         return true;
       }
-      const avenants = data.actesAdministratifs.filter(
+      const avenants = data.actesAdministratifs?.filter(
         (acteAdministratif) => acteAdministratif.parentId
-      );
+      ) ?? [];
       for (const acteAdministratif of avenants) {
         const avenantEndDate = formatDateToIsoString(acteAdministratif.endDate);
 


### PR DESCRIPTION
## Summary
- Ajoute la catégorie "AUTRE" pour les actes administratifs des CPOMs (uploader des documents complémentaires avec un nom libre, optionnels et sans avenant)
- Sécurise le calcul des dates du CPOM en filtrant explicitement sur la catégorie `CONVENTION` (côté formulaire) ; le calcul côté API était déjà hardcodé sur CONVENTION
- Corrige un bug de validation qui cherchait la convention par `!parentId`, ce qui aurait matché les actes AUTRE (qui n'ont pas non plus de `parentId`)

## Test plan
- [ ] Aller sur `/cpoms/[id]/modification/actes-administratifs` : la section "Autres documents (optionnel)" apparaît sous le contrat CPOM
- [ ] Ajouter un document AUTRE avec un nom et un fichier, sauvegarder, vérifier que les dates du CPOM n'ont pas changé
- [ ] Vérifier qu'une ligne AUTRE laissée vide est silencieusement ignorée à la sauvegarde
- [ ] Vérifier que la validation des avenants CONVENTION fonctionne toujours (date avenant >= date fin convention)
- [ ] Sur une fiche structure, l'accordéon CPOM affiche bien à la fois les actes CONVENTION et AUTRE du CPOM