### PR TITLE
:spider_web: Spiderfy clusters for structure map

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@codegouvfr/react-dsfr": "^1.32.4",
     "@formkit/auto-animate": "^0.9.0",
     "@hookform/resolvers": "^5.4.0",
+    "@nazka/map-gl-js-spiderfy": "^2.0.0",
     "@prisma/adapter-pg": "^7.7.0",
     "@prisma/client": "^7.7.0",
     "@sentry/nextjs": "^10",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -38,6 +38,8 @@ import {
 } from "./seeders/operateur.seed";
 import { createFakeRmus } from "./seeders/rmu.seed";
 import {
+  COLOCATED_COORDINATES,
+  COLOCATED_STRUCTURES_COUNT,
   FormDefLookup,
   SeededStructure,
   seedStructureWithVersions,
@@ -201,6 +203,7 @@ async function seed(): Promise<void> {
 
   const now = new Date();
   const seededStructures: SeededStructure[] = [];
+  let colocatedLeft = COLOCATED_STRUCTURES_COUNT;
 
   for (const operateurToInsert of operateursToInsert) {
     const createdOperateur = await prisma.operateur.create({
@@ -227,6 +230,11 @@ async function seed(): Promise<void> {
       const departementAdministratif = randomDepartement();
       const codeBhasile = nextCodeBhasile(departementAdministratif);
 
+      const colocated = !ofii && colocatedLeft > 0;
+      if (colocated) {
+        colocatedLeft--;
+      }
+
       const seeded = await seedStructureWithVersions(prisma, {
         operateurId: createdOperateur.id,
         codeBhasile,
@@ -239,6 +247,7 @@ async function seed(): Promise<void> {
         finalisationFormDefId: formFinalisationDefinition.id,
         finalisationStepDefinitions: stepDefinitions,
         initialisationCampaignDefinitionId: initialisationCampaignDefinition.id,
+        coordinates: colocated ? COLOCATED_COORDINATES : undefined,
       });
       seededStructures.push(seeded);
       operateurStructureIds.push(seeded.structureId);

--- a/prisma/seeders/structure-version.seed.ts
+++ b/prisma/seeders/structure-version.seed.ts
@@ -27,6 +27,22 @@ import { createFakeStructureTypologie } from "./structure-typologie.seed";
 export type FormDefInfo = { id: number; stepDefinitionIds: number[] };
 export type FormDefLookup = Map<string, FormDefInfo>;
 
+export type Coordinates = { latitude: number; longitude: number };
+
+const STRUCTURE_ZONE = {
+  minLatitude: 43.550851,
+  maxLatitude: 49.131627,
+  minLongitude: -0.851371,
+  maxLongitude: 5.843377,
+};
+
+export const COLOCATED_COORDINATES: Coordinates = {
+  latitude: STRUCTURE_ZONE.maxLatitude - 0.05,
+  longitude: STRUCTURE_ZONE.minLongitude + 0.05,
+};
+
+export const COLOCATED_STRUCTURES_COUNT = 4;
+
 export type SeedStructureParams = {
   operateurId: number;
   codeBhasile: string;
@@ -39,6 +55,7 @@ export type SeedStructureParams = {
   finalisationFormDefId: number;
   finalisationStepDefinitions: { id: number; slug: string }[];
   initialisationCampaignDefinitionId: number;
+  coordinates?: Coordinates;
 };
 
 export type SeededStructure = { structureId: number; currentVersionId: number };
@@ -178,7 +195,8 @@ type VersionScalars = {
 
 const buildVersionScalars = (
   departementAdministratif: string,
-  ofii: boolean
+  ofii: boolean,
+  coordinates?: Coordinates
 ): VersionScalars => {
   const base: VersionScalars = {
     nom: faker.lorem.words(2),
@@ -197,10 +215,18 @@ const buildVersionScalars = (
     communeAdministrative: faker.location.city(),
     codePostalAdministratif: faker.location.zipCode(),
     latitude: new Prisma.Decimal(
-      faker.location.latitude({ min: 43.550851, max: 49.131627 })
+      coordinates?.latitude ??
+        faker.location.latitude({
+          min: STRUCTURE_ZONE.minLatitude,
+          max: STRUCTURE_ZONE.maxLatitude,
+        })
     ),
     longitude: new Prisma.Decimal(
-      faker.location.longitude({ min: -0.851371, max: 5.843377 })
+      coordinates?.longitude ??
+        faker.location.longitude({
+          min: STRUCTURE_ZONE.minLongitude,
+          max: STRUCTURE_ZONE.maxLongitude,
+        })
     ),
     public: faker.helpers.enumValue(PublicType),
     notes: faker.lorem.lines(2),
@@ -535,7 +561,8 @@ export const seedStructureWithVersions = async (
   const plan = planStructureHistory(params.ofii, params.now);
   const scalars = buildVersionScalars(
     params.departementAdministratif,
-    params.ofii
+    params.ofii,
+    params.coordinates
   );
   const contacts: StableContacts = params.ofii
     ? []

--- a/src/app/components/map/Map.tsx
+++ b/src/app/components/map/Map.tsx
@@ -28,8 +28,8 @@ import {
 import { MapLibreProvider, MapRegisteredPoint } from "./MapContext";
 import { bindStructuresInteractions } from "./structuresInteractions";
 import {
+  addStructuresImages,
   addStructuresLayers,
-  addStructuresMarkerImage,
   addStructuresSource,
   STRUCTURES_SOURCE_ID,
 } from "./structuresStyle";
@@ -153,7 +153,7 @@ export const Map = ({ children }: PropsWithChildren): ReactElement => {
       );
 
       addStructuresSource(createdMap);
-      await addStructuresMarkerImage(createdMap);
+      await addStructuresImages(createdMap);
       addStructuresLayers(createdMap);
 
       const cleanupInteractions = bindStructuresInteractions({

--- a/src/app/components/map/structuresInteractions.ts
+++ b/src/app/components/map/structuresInteractions.ts
@@ -1,20 +1,29 @@
 "use client";
 
+import Spiderfy from "@nazka/map-gl-js-spiderfy";
 import maplibregl from "maplibre-gl";
 import { RefObject } from "react";
 import { Root } from "react-dom/client";
 
+import { MAX_MAP_ZOOM } from "@/constants";
+
 import { MapRegisteredPoint } from "./MapContext";
 import { getOrCreatePopup } from "./structuresPopup";
 import {
+  STRUCTURE_MARKER_LAYOUT,
+  STRUCTURES_CLUSTER_FILTER,
   STRUCTURES_LAYER_CLUSTERS_ID,
   STRUCTURES_LAYER_UNCLUSTERED_ID,
   STRUCTURES_SOURCE_ID,
 } from "./structuresStyle";
 
+const SPIDERFY_LEAF_LAYER_PREFIX = `${STRUCTURES_LAYER_CLUSTERS_ID}-spiderfy-leaf`;
+const SPIDERFY_FIRST_LEAF_LAYER_ID = `${SPIDERFY_LEAF_LAYER_PREFIX}0`;
+const SAME_POSITION_EPSILON = 1e-9;
+
 type LngLatTuple = [number, number];
 
-const isLngLatTuple = (value: unknown): value is LngLatTuple => {
+const isNumberPair = (value: unknown): value is [number, number] => {
   return (
     Array.isArray(value) &&
     value.length === 2 &&
@@ -34,52 +43,7 @@ export const bindStructuresInteractions = ({
   popupRef: React.RefObject<maplibregl.Popup | null>;
   popupRootRef: React.RefObject<Root | null>;
 }): (() => void) => {
-  const onClusterClick = async (e: maplibregl.MapLayerMouseEvent) => {
-    const features = map.queryRenderedFeatures(e.point, {
-      layers: [STRUCTURES_LAYER_CLUSTERS_ID],
-    });
-    const first = features[0];
-    if (!first) {
-      return;
-    }
-
-    const clusterIdRaw = first.properties?.cluster_id;
-    const clusterId =
-      typeof clusterIdRaw === "number" ? clusterIdRaw : undefined;
-    if (clusterId == null) {
-      return;
-    }
-
-    const src = map.getSource(
-      STRUCTURES_SOURCE_ID
-    ) as maplibregl.GeoJSONSource & {
-      getClusterExpansionZoom: (clusterId: number) => Promise<number>;
-    };
-
-    const zoom = await src.getClusterExpansionZoom(clusterId);
-    const coordsUnknown = (first.geometry as { coordinates?: unknown })
-      .coordinates;
-    if (!isLngLatTuple(coordsUnknown)) {
-      return;
-    }
-    const coords = coordsUnknown;
-    map.easeTo({ center: coords, zoom });
-  };
-
-  const onUnclusteredClick = (e: maplibregl.MapLayerMouseEvent) => {
-    const feature = e.features?.[0];
-    if (!feature) {
-      return;
-    }
-
-    const coordsUnknown = (feature.geometry as { coordinates?: unknown })
-      .coordinates;
-    if (!isLngLatTuple(coordsUnknown)) {
-      return;
-    }
-    const coords = coordsUnknown;
-
-    const id = String(feature.properties?.id ?? "");
+  const openPopup = (id: string, coords: LngLatTuple) => {
     const registered = pointsRef.current?.get(id);
     if (!registered) {
       return;
@@ -90,7 +54,127 @@ export const bindStructuresInteractions = ({
     popup.setLngLat(coords).addTo(map);
   };
 
+  const findSpiderfyLeafAt = (point: maplibregl.Point) => {
+    return map
+      .queryRenderedFeatures(point)
+      .find((feature) =>
+        feature.layer.id.startsWith(SPIDERFY_LEAF_LAYER_PREFIX)
+      );
+  };
+
+  const getCoordinates = (feature: {
+    geometry: unknown;
+  }): LngLatTuple | null => {
+    const coords = (feature.geometry as { coordinates?: unknown }).coordinates;
+    return isNumberPair(coords) ? coords : null;
+  };
+
+  let hiddenClusterId: number | null = null;
+
+  const hideCluster = (clusterId: number | null) => {
+    if (clusterId === hiddenClusterId) {
+      return;
+    }
+    hiddenClusterId = clusterId;
+    map.setFilter(
+      STRUCTURES_LAYER_CLUSTERS_ID,
+      clusterId === null
+        ? STRUCTURES_CLUSTER_FILTER
+        : [
+            "all",
+            STRUCTURES_CLUSTER_FILTER,
+            ["!=", ["get", "cluster_id"], clusterId],
+          ]
+    );
+  };
+
+  const syncSpiderfiedCluster = () => {
+    if (!map.getLayer(SPIDERFY_FIRST_LEAF_LAYER_ID)) {
+      hideCluster(null);
+      return;
+    }
+
+    const [leaf] = map.querySourceFeatures(SPIDERFY_FIRST_LEAF_LAYER_ID);
+    const spiderfied = leaf ? getCoordinates(leaf) : null;
+    if (!spiderfied) {
+      hideCluster(null);
+      return;
+    }
+
+    const cluster = map.querySourceFeatures(STRUCTURES_SOURCE_ID).find((f) => {
+      if (!f.properties?.cluster) {
+        return false;
+      }
+      const coords = getCoordinates(f);
+      return (
+        coords !== null &&
+        Math.abs(coords[0] - spiderfied[0]) < SAME_POSITION_EPSILON &&
+        Math.abs(coords[1] - spiderfied[1]) < SAME_POSITION_EPSILON
+      );
+    });
+
+    const clusterId = cluster?.properties?.cluster_id;
+    hideCluster(typeof clusterId === "number" ? clusterId : null);
+  };
+
+  const getLeafAnchor = (
+    leaf: maplibregl.MapGeoJSONFeature
+  ): LngLatTuple | null => {
+    const coordsUnknown = (leaf.geometry as { coordinates?: unknown })
+      .coordinates;
+    if (!isNumberPair(coordsUnknown)) {
+      return null;
+    }
+
+    const offset = map.getLayoutProperty(leaf.layer.id, "icon-offset");
+    if (!isNumberPair(offset)) {
+      return coordsUnknown;
+    }
+
+    const projected = map.project(coordsUnknown);
+    const anchor = map.unproject([
+      projected.x + offset[0],
+      projected.y + offset[1],
+    ]);
+    return [anchor.lng, anchor.lat];
+  };
+
+  const spiderfy = new Spiderfy(map, {
+    forceSpiderifyMinZoom: MAX_MAP_ZOOM,
+    closeOnLeafClick: false,
+    spiderLeavesLayout: STRUCTURE_MARKER_LAYOUT,
+    spiderLeavesPaint: {},
+    onLeafClick: (feature, event) => {
+      const rendered = findSpiderfyLeafAt(event.point);
+      const anchor = rendered ? getLeafAnchor(rendered) : null;
+      openPopup(
+        String(feature.properties?.id ?? ""),
+        anchor ?? [event.lngLat.lng, event.lngLat.lat]
+      );
+    },
+  });
+  spiderfy.applyTo(STRUCTURES_LAYER_CLUSTERS_ID);
+
+  const onUnclusteredClick = (e: maplibregl.MapLayerMouseEvent) => {
+    const feature = e.features?.[0];
+    if (!feature) {
+      return;
+    }
+
+    const coordsUnknown = (feature.geometry as { coordinates?: unknown })
+      .coordinates;
+    if (!isNumberPair(coordsUnknown)) {
+      return;
+    }
+
+    openPopup(String(feature.properties?.id ?? ""), coordsUnknown);
+  };
+
   const onMapClick = (event: maplibregl.MapMouseEvent) => {
+    if (findSpiderfyLeafAt(event.point)) {
+      return;
+    }
+
     const features = map.queryRenderedFeatures(event.point, {
       layers: [STRUCTURES_LAYER_UNCLUSTERED_ID],
     });
@@ -113,7 +197,7 @@ export const bindStructuresInteractions = ({
     map.getCanvas().style.cursor = "";
   };
 
-  map.on("click", STRUCTURES_LAYER_CLUSTERS_ID, onClusterClick);
+  map.on("idle", syncSpiderfiedCluster);
   map.on("click", STRUCTURES_LAYER_UNCLUSTERED_ID, onUnclusteredClick);
   map.on("click", onMapClick);
   map.on("mouseenter", STRUCTURES_LAYER_CLUSTERS_ID, onMouseEnterClusters);
@@ -130,7 +214,8 @@ export const bindStructuresInteractions = ({
   );
 
   return () => {
-    map.off("click", STRUCTURES_LAYER_CLUSTERS_ID, onClusterClick);
+    spiderfy.unspiderfyAll();
+    map.off("idle", syncSpiderfiedCluster);
     map.off("click", STRUCTURES_LAYER_UNCLUSTERED_ID, onUnclusteredClick);
     map.off("click", onMapClick);
     map.off("mouseenter", STRUCTURES_LAYER_CLUSTERS_ID, onMouseEnterClusters);

--- a/src/app/components/map/structuresInteractions.ts
+++ b/src/app/components/map/structuresInteractions.ts
@@ -32,6 +32,11 @@ const isNumberPair = (value: unknown): value is [number, number] => {
   );
 };
 
+const getCoordinates = (feature: { geometry: unknown }): LngLatTuple | null => {
+  const coords = (feature.geometry as { coordinates?: unknown }).coordinates;
+  return isNumberPair(coords) ? coords : null;
+};
+
 export const bindStructuresInteractions = ({
   map,
   pointsRef,
@@ -60,13 +65,6 @@ export const bindStructuresInteractions = ({
       .find((feature) =>
         feature.layer.id.startsWith(SPIDERFY_LEAF_LAYER_PREFIX)
       );
-  };
-
-  const getCoordinates = (feature: {
-    geometry: unknown;
-  }): LngLatTuple | null => {
-    const coords = (feature.geometry as { coordinates?: unknown }).coordinates;
-    return isNumberPair(coords) ? coords : null;
   };
 
   let hiddenClusterId: number | null = null;
@@ -120,18 +118,17 @@ export const bindStructuresInteractions = ({
   const getLeafAnchor = (
     leaf: maplibregl.MapGeoJSONFeature
   ): LngLatTuple | null => {
-    const coordsUnknown = (leaf.geometry as { coordinates?: unknown })
-      .coordinates;
-    if (!isNumberPair(coordsUnknown)) {
+    const coords = getCoordinates(leaf);
+    if (!coords) {
       return null;
     }
 
     const offset = map.getLayoutProperty(leaf.layer.id, "icon-offset");
     if (!isNumberPair(offset)) {
-      return coordsUnknown;
+      return coords;
     }
 
-    const projected = map.project(coordsUnknown);
+    const projected = map.project(coords);
     const anchor = map.unproject([
       projected.x + offset[0],
       projected.y + offset[1],
@@ -161,13 +158,12 @@ export const bindStructuresInteractions = ({
       return;
     }
 
-    const coordsUnknown = (feature.geometry as { coordinates?: unknown })
-      .coordinates;
-    if (!isNumberPair(coordsUnknown)) {
+    const coords = getCoordinates(feature);
+    if (!coords) {
       return;
     }
 
-    openPopup(String(feature.properties?.id ?? ""), coordsUnknown);
+    openPopup(String(feature.properties?.id ?? ""), coords);
   };
 
   const onMapClick = (event: maplibregl.MapMouseEvent) => {

--- a/src/app/components/map/structuresInteractions.ts
+++ b/src/app/components/map/structuresInteractions.ts
@@ -99,17 +99,19 @@ export const bindStructuresInteractions = ({
       return;
     }
 
-    const cluster = map.querySourceFeatures(STRUCTURES_SOURCE_ID).find((f) => {
-      if (!f.properties?.cluster) {
-        return false;
-      }
-      const coords = getCoordinates(f);
-      return (
-        coords !== null &&
-        Math.abs(coords[0] - spiderfied[0]) < SAME_POSITION_EPSILON &&
-        Math.abs(coords[1] - spiderfied[1]) < SAME_POSITION_EPSILON
-      );
-    });
+    const cluster = map
+      .querySourceFeatures(STRUCTURES_SOURCE_ID)
+      .find((feature) => {
+        if (!feature.properties?.cluster) {
+          return false;
+        }
+        const coords = getCoordinates(feature);
+        return (
+          coords !== null &&
+          Math.abs(coords[0] - spiderfied[0]) < SAME_POSITION_EPSILON &&
+          Math.abs(coords[1] - spiderfied[1]) < SAME_POSITION_EPSILON
+        );
+      });
 
     const clusterId = cluster?.properties?.cluster_id;
     hideCluster(typeof clusterId === "number" ? clusterId : null);

--- a/src/app/components/map/structuresStyle.ts
+++ b/src/app/components/map/structuresStyle.ts
@@ -2,12 +2,22 @@
 
 import maplibregl from "maplibre-gl";
 
+import { MAX_MAP_ZOOM } from "@/constants";
+
 const SINGLE_MARKER_IMAGE_ID = "structure-marker";
 const SINGLE_MARKER_PUBLIC_PATH = "/structure-marker.svg";
 export const STRUCTURES_SOURCE_ID = "structures";
 export const STRUCTURES_LAYER_CLUSTERS_ID = "structure-clusters";
-const STRUCTURES_LAYER_CLUSTER_COUNT_ID = "structure-cluster-count";
 export const STRUCTURES_LAYER_UNCLUSTERED_ID = "structure-unclustered-point";
+
+const CLUSTER_SMALL_IMAGE_ID = "structure-cluster-small";
+const CLUSTER_MEDIUM_IMAGE_ID = "structure-cluster-medium";
+const CLUSTER_LARGE_IMAGE_ID = "structure-cluster-large";
+
+const CLUSTER_FILL_COLOR = "#000091";
+const CLUSTER_STROKE_COLOR = "#DDDDDD";
+const CLUSTER_STROKE_WIDTH = 2;
+const CLUSTER_PIXEL_RATIO = 2;
 
 const addSingleMarkerImage = async (map: maplibregl.Map): Promise<void> => {
   if (map.hasImage(SINGLE_MARKER_IMAGE_ID)) {
@@ -27,44 +37,94 @@ const addSingleMarkerImage = async (map: maplibregl.Map): Promise<void> => {
   map.addImage(SINGLE_MARKER_IMAGE_ID, img);
 };
 
+const addClusterCircleImage = (
+  map: maplibregl.Map,
+  id: string,
+  radius: number
+): void => {
+  if (map.hasImage(id)) {
+    return;
+  }
+
+  const diameter = (radius + CLUSTER_STROKE_WIDTH) * 2;
+  const size = diameter * CLUSTER_PIXEL_RATIO;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Échec de la création de l'icône du cluster.");
+  }
+
+  context.scale(CLUSTER_PIXEL_RATIO, CLUSTER_PIXEL_RATIO);
+  const center = radius + CLUSTER_STROKE_WIDTH;
+  context.beginPath();
+  context.arc(center, center, radius, 0, 2 * Math.PI);
+  context.fillStyle = CLUSTER_FILL_COLOR;
+  context.fill();
+  context.lineWidth = CLUSTER_STROKE_WIDTH;
+  context.strokeStyle = CLUSTER_STROKE_COLOR;
+  context.stroke();
+
+  map.addImage(id, context.getImageData(0, 0, size, size), {
+    pixelRatio: CLUSTER_PIXEL_RATIO,
+  });
+};
+
 export const addStructuresMarkerImage = async (
   map: maplibregl.Map
 ): Promise<void> => {
   await addSingleMarkerImage(map);
+  addClusterCircleImage(map, CLUSTER_SMALL_IMAGE_ID, 18);
+  addClusterCircleImage(map, CLUSTER_MEDIUM_IMAGE_ID, 24);
+  addClusterCircleImage(map, CLUSTER_LARGE_IMAGE_ID, 30);
 };
+
+export const STRUCTURE_MARKER_LAYOUT: maplibregl.SymbolLayerSpecification["layout"] =
+  {
+    "icon-image": SINGLE_MARKER_IMAGE_ID,
+    "icon-size": 1,
+    "icon-anchor": "bottom",
+    "icon-allow-overlap": true,
+  };
 
 export const addStructuresSource = (map: maplibregl.Map): void => {
   map.addSource(STRUCTURES_SOURCE_ID, {
     type: "geojson",
     data: { type: "FeatureCollection", features: [] },
     cluster: true,
-    clusterMaxZoom: 14,
+    clusterMaxZoom: MAX_MAP_ZOOM,
     clusterRadius: 50,
   });
 };
 
+export const STRUCTURES_CLUSTER_FILTER: maplibregl.ExpressionSpecification = [
+  "has",
+  "point_count",
+];
+
 export const addStructuresLayers = (map: maplibregl.Map): void => {
   map.addLayer({
     id: STRUCTURES_LAYER_CLUSTERS_ID,
-    type: "circle",
-    source: STRUCTURES_SOURCE_ID,
-    filter: ["has", "point_count"],
-    paint: {
-      "circle-color": "#000091",
-      "circle-radius": ["step", ["get", "point_count"], 18, 50, 24, 200, 30],
-      "circle-stroke-width": 2,
-      "circle-stroke-color": "#DDDDDD",
-    },
-  });
-
-  map.addLayer({
-    id: STRUCTURES_LAYER_CLUSTER_COUNT_ID,
     type: "symbol",
     source: STRUCTURES_SOURCE_ID,
-    filter: ["has", "point_count"],
+    filter: STRUCTURES_CLUSTER_FILTER,
     layout: {
+      "icon-image": [
+        "step",
+        ["get", "point_count"],
+        CLUSTER_SMALL_IMAGE_ID,
+        50,
+        CLUSTER_MEDIUM_IMAGE_ID,
+        200,
+        CLUSTER_LARGE_IMAGE_ID,
+      ],
+      "icon-allow-overlap": true,
       "text-field": "{point_count_abbreviated}",
       "text-size": 12,
+      "text-allow-overlap": true,
     },
     paint: {
       "text-color": "#FFFFFF",
@@ -76,11 +136,6 @@ export const addStructuresLayers = (map: maplibregl.Map): void => {
     type: "symbol",
     source: STRUCTURES_SOURCE_ID,
     filter: ["!", ["has", "point_count"]],
-    layout: {
-      "icon-image": SINGLE_MARKER_IMAGE_ID,
-      "icon-size": 1,
-      "icon-anchor": "bottom",
-      "icon-allow-overlap": true,
-    },
+    layout: STRUCTURE_MARKER_LAYOUT,
   });
 };

--- a/src/app/components/map/structuresStyle.ts
+++ b/src/app/components/map/structuresStyle.ts
@@ -73,7 +73,7 @@ const addClusterCircleImage = (
   });
 };
 
-export const addStructuresMarkerImage = async (
+export const addStructuresImages = async (
   map: maplibregl.Map
 ): Promise<void> => {
   await addSingleMarkerImage(map);
@@ -135,7 +135,7 @@ export const addStructuresLayers = (map: maplibregl.Map): void => {
     id: STRUCTURES_LAYER_UNCLUSTERED_ID,
     type: "symbol",
     source: STRUCTURES_SOURCE_ID,
-    filter: ["!", ["has", "point_count"]],
+    filter: ["!", STRUCTURES_CLUSTER_FILTER],
     layout: STRUCTURE_MARKER_LAYOUT,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,11 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
 
+"@nazka/map-gl-js-spiderfy@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nazka/map-gl-js-spiderfy/-/map-gl-js-spiderfy-2.0.0.tgz#7b9324625c12d42ed37528e4218e9186d5f2ecef"
+  integrity sha512-puFWuTXtsoFKEFlmaF1EcPhRZRIuvsGwuYmVPNT0nTbVHXC//jKJa57uxfwVps01AQJBiyewQ30ElUzv8Kp3fg==
+
 "@next/env@16.2.10":
   version "16.2.10"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-16.2.10.tgz#0e9473a5577807292e11d3bf9e075d3bf036860f"


### PR DESCRIPTION
On réintroduit cette gestion des clusters, non native dans maplibre 
<img width="508" height="482" alt="image" src="https://github.com/user-attachments/assets/83f472a7-70c4-4cc1-a7e1-93f653b8d814" />

