### PR TITLE
:alembic: Try to fix seeders

### DIFF
--- a/prisma/client.ts
+++ b/prisma/client.ts
@@ -4,7 +4,9 @@ import { PrismaClient } from "@/generated/prisma/client";
 
 export const DATABASE_POOL_MAX = Number(process.env.DATABASE_POOL_MAX) || 10;
 
-export const createPrismaClient = () => {
+export const createPrismaClient = ({
+  queryPlanCacheMaxSize,
+}: { queryPlanCacheMaxSize?: number } = {}) => {
   const connectionString = process.env.DATABASE_URL;
 
   if (!connectionString) {
@@ -17,5 +19,5 @@ export const createPrismaClient = () => {
     connectionTimeoutMillis: 5_000,
     application_name: process.env.CONTAINER ?? "bhasile",
   });
-  return new PrismaClient({ adapter });
+  return new PrismaClient({ adapter, queryPlanCacheMaxSize });
 };

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -53,7 +53,8 @@ import {
 import { convertToPrismaObject } from "./utils/common.util";
 import { wipeTables } from "./utils/wipe";
 
-const prisma = createPrismaClient();
+// Le cache ne sert à rien et retient un plan par structure jusqu'à saturation (1000 par défaut) -> on l'annule.
+const prisma = createPrismaClient({ queryPlanCacheMaxSize: 0 });
 
 // Graine fixe : les tests repository tournent en CI sur ce jeu de données.
 // Surcharger via FAKER_SEED pour rejouer un échec observé avec une autre graine.


### PR DESCRIPTION
On essaye de fix ça (sur seed Scalingo)


```
See https://www.postgresql.org/docs/current/libpq-ssl.html for libpq SSL mode definitions.
(Use `node --trace-warnings ...` to show where the warning was created)
🌍 Départements et régions créés
🧑 Création des rôles et des utilisateurs test...
🧑 3 agents de test créés : national@test.proconnect.gouv.fr, regional@test.proconnect.gouv.fr, departemental@test.proconnect.gouv.fr
📋 Création des FormDefinitions...
✅ 6 FormStepDefinitions créées pour le formulaire finalisation
🚓 Création des données RMU...
✅ 392 lignes Rmu créées
🔢 Génération des codes Bhasile par région...
✅ Codes Bhasile générés
🏢 Création des opérateurs et de leurs filiales...
🏢 Filiale créée : Opérateur 1 - Filiale
🏠 226 structures et 91 structures OFII prévues pour Opérateur 1
🏠 210 structures et 63 structures OFII prévues pour Opérateur 2
🏠 228 structures et 79 structures OFII prévues pour Opérateur 3
🏠 225 structures et 73 structures OFII prévues pour Opérateur 4
🏠 244 structures et 60 structures OFII prévues pour Opérateur 5
🏠 200/1499 structures créées
🏠 400/1499 structures créées

<--- Last few GCs --->

[192:0x26b79000]    13439 ms: Incremental Mark-Compact (reduce) 254.9 (258.5) -> 253.9 (257.0) MB, pooled: 0.0 MB, 50.07 / 0.00 ms (+ 0.1 ms in 37 steps since start of marking, biggest step 0.0 ms, walltime since start of marking 60 ms) (average mu = 0.26
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x81d53b node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/app/.scalingo/node/bin/node]
 2: 0xc6d46b  [/app/.scalingo/node/bin/node]
 3: 0xede4f5  [/app/.scalingo/node/bin/node]
 4: 0xedc6fc  [/app/.scalingo/node/bin/node]
 5: 0xecf794  [/app/.scalingo/node/bin/node]
 6: 0xecf5bc  [/app/.scalingo/node/bin/node]
 7: 0xecef4f  [/app/.scalingo/node/bin/node]
 8: 0xeab0dd  [/app/.scalingo/node/bin/node]
 9: 0x1369601  [/app/.scalingo/node/bin/node]
10: 0x1a7fa76  [/app/.scalingo/node/bin/node]

An error occurred while running the seed command:
Error: Command failed with exit code 134: tsx prisma/seed.ts
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```